### PR TITLE
Add a static cast to op_in_r assignment

### DIFF
--- a/alu.sv
+++ b/alu.sv
@@ -35,7 +35,7 @@ module alu #(
         // Register all inputs
         always_ff @ (posedge clk, posedge rst) begin
                 if (rst) begin
-                        op_in_r     <= '0;
+                        op_in_r     <= operation_t'(0);
                         a_in_r      <= '0;
                         b_in_r      <= '0;
                         in_valid_r  <= '0;


### PR DESCRIPTION
In the case where rst is high when registering inputs, some later versions of verilator throw an error. By statically casting the initialisation value this explicitly converts the value and therefore does not cause a warning.

My apologies if this is poorly understood, I am very new to verilog and am working off what little I have gleaned from the verilator docs.

Verilator docs page: https://verilator.org/guide/latest/warnings.html#cmdoption-arg-ENUMVALUE
Verilator version: `Verilator 5.006 2023-01-22 rev (Debian 5.006-2)`